### PR TITLE
Add CmSystemInfo/WanStatus/LanStatus apis

### DIFF
--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -46,6 +46,7 @@ CMD_TEMPERATURE = 136
 CMD_CMSTATUS = 144
 CMD_EVENTLOG = 13
 CMD_CMSYSTEMINFO = 2
+CMD_REBOOT = 8
 CMD_LANSTATUS = 100
 CMD_WANSTATUS = 107
 
@@ -447,6 +448,15 @@ class ConnectBox:
             self.token = None
             raise exceptions.ConnectBoxNoDataAvailable() from None
         self.eventlog.sort(key=(lambda e: e.evEpoch))
+
+    async def async_reboot_device(self) -> None:
+        if self.token is None:
+            await self.async_initialize_token()
+
+        await self._async_ws_set_function(CMD_REBOOT, params={})
+
+        # At this point the device must be restarting, so the token becomes invalid
+        self.token = None
 
     async def async_close_session(self) -> None:
         """Logout and close session."""

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -80,6 +80,7 @@ class ConnectBox:
         self.upstream_service_flows: List[ServiceFlow] = []
         self.downstream_service_flows: List[ServiceFlow] = []
         self.temperature: Optional[Temperature] = None
+        self.eventlog: List[LogEvent] = []
         self.lanstatus: Optional[LanStatus] = None
         self.wanstatus: Optional[WanStatus] = None
         self.cm_systeminfo: Optional[CmSystemInfo] = None
@@ -89,7 +90,7 @@ class ConnectBox:
         if self.token is None:
             await self.async_initialize_token()
 
-        self.devices.clear()
+        self.devices = []
         raw = await self._async_ws_get_function(CMD_DEVICES)
 
         try:
@@ -146,7 +147,7 @@ class ConnectBox:
         if self.token is None:
             await self.async_initialize_token()
 
-        self.ds_channels.clear()
+        self.ds_channels = []
         raw = await self._async_ws_get_function(CMD_DOWNSTREAM)
 
         try:
@@ -176,7 +177,7 @@ class ConnectBox:
         if self.token is None:
             await self.async_initialize_token()
 
-        self.us_channels.clear()
+        self.us_channels = []
         raw = await self._async_ws_get_function(CMD_UPSTREAM)
 
         try:
@@ -208,7 +209,7 @@ class ConnectBox:
         if self.token is None:
             await self.async_initialize_token()
 
-        self.ipv6_filters.clear()
+        self.ipv6_filters = []
         self._ipv6_filters_time = None
         raw = await self._async_ws_get_function(CMD_GET_IPV6_FILTER_RULE)
 
@@ -308,7 +309,7 @@ class ConnectBox:
             await self.async_initialize_token()
 
         self.lanstatus = None
-        raw = await self._async_ws_get_function(CMD_LANSETTING)
+        raw = await self._async_ws_get_function(CMD_LANSTATUS)
         try:
             xml_root = element_tree.fromstring(raw)
             self.lanstatus = LanStatus(

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -1,54 +1,50 @@
 """A Python Client to get data from UPC Connect Boxes."""
 import asyncio
+from collections import OrderedDict
 import logging
 from typing import Dict, List, Optional
-from collections import OrderedDict
 
-import attr
 import aiohttp
 from aiohttp.hdrs import REFERER, USER_AGENT
 import defusedxml.ElementTree as element_tree
 
-from .parsers import _parse_general_time, _parse_daily_time
-
+from . import exceptions
 from .data import (
+    CmStatus,
     CmSystemInfo,
-    LanStatus,
-    WanStatus,
     Device,
     DownstreamChannel,
-    UpstreamChannel,
-    CmStatus,
+    FilterState,
+    FilterStatesList,
+    FiltersTimeMode,
+    Ipv6FilterInstance,
+    LanStatus,
+    LogEvent,
     ServiceFlow,
     Temperature,
-    Ipv6FilterInstance, 
-    FilterState, 
-    FilterStatesList, 
-    FiltersTimeMode,
-    LogEvent,
+    UpstreamChannel,
+    WanStatus,
 )
-
-from . import exceptions
-
+from .parsers import _parse_daily_time, _parse_general_time
 
 _LOGGER = logging.getLogger(__name__)
 
 HTTP_HEADER_X_REQUESTED_WITH = "X-Requested-With"
 
-CMD_LOGIN = 15
-CMD_LOGOUT = 16
-CMD_DEVICES = 123
-CMD_DOWNSTREAM = 10
-CMD_UPSTREAM = 11
-CMD_GET_IPV6_FILTER_RULE = 111
-CMD_SET_IPV6_FILTER_RULE = 112
-CMD_TEMPERATURE = 136
-CMD_CMSTATUS = 144
-CMD_EVENTLOG = 13
 CMD_CMSYSTEMINFO = 2
 CMD_REBOOT = 8
+CMD_DOWNSTREAM = 10
+CMD_UPSTREAM = 11
+CMD_EVENTLOG = 13
+CMD_LOGIN = 15
+CMD_LOGOUT = 16
 CMD_LANSTATUS = 100
 CMD_WANSTATUS = 107
+CMD_GET_IPV6_FILTER_RULE = 111
+CMD_SET_IPV6_FILTER_RULE = 112
+CMD_DEVICES = 123
+CMD_TEMPERATURE = 136
+CMD_CMSTATUS = 144
 
 
 class ConnectBox:
@@ -236,7 +232,7 @@ class ConnectBox:
             self._ipv6_filters_time = FiltersTimeMode(
                 int(xml_root.find("time_mode").text),
                 _parse_general_time(xml_root),
-                _parse_daily_time(xml_root)
+                _parse_daily_time(xml_root),
             )
 
         except (element_tree.ParseError, TypeError):
@@ -247,43 +243,48 @@ class ConnectBox:
     async def _async_get_ipv6_filter_states(self) -> FilterStatesList:
         """Get enable/disable states of IPv6 filter instances"""
         await self.async_get_ipv6_filtering()
-        return FilterStatesList(list(FilterState(filter_instance.idd, filter_instance.enabled) for filter_instance in self.ipv6_filters))
+        return FilterStatesList(
+            list(
+                FilterState(filter_instance.idd, filter_instance.enabled)
+                for filter_instance in self.ipv6_filters
+            )
+        )
 
     async def _async_update_ipv6_filter_states(self, filter_states: FilterStatesList):
         """Update enable/disable states of IPv6 filters while not affecting any other setting"""
         if self.token is None:
             await self.async_initialize_token()
 
-        val_enabled = '*'.join([str(fs.enabled) for fs in filter_states.entries])
-        val_del = '*'.join(['0' for fs in filter_states.entries])
-        val_idd = '*'.join([str(fs.idd) for fs in filter_states.entries])
+        val_enabled = "*".join([str(fs.enabled) for fs in filter_states.entries])
+        val_del = "*".join(["0" for fs in filter_states.entries])
+        val_idd = "*".join([str(fs.idd) for fs in filter_states.entries])
 
         params = OrderedDict()
-        params['act'] = 1
-        params['dir'] = 0
-        params['enabled'] = val_enabled
-        params['allow_traffic'] = ''
-        params['protocol'] = ''
-        params['src_addr'] = ''
-        params['src_prefix'] = ''
-        params['dst_addr'] = ''
-        params['dst_prefix'] = ''
-        params['ssport'] = ''
-        params['seport'] = ''
-        params['dsport'] = ''
-        params['deport'] = ''
-        params['del'] = val_del
-        params['idd'] = val_idd
-        params['sIpRange'] = ''
-        params['dsIpRange'] = ''
-        params['PortRange'] = ''
-        params['TMode'] = self._ipv6_filters_time.TMode
+        params["act"] = 1
+        params["dir"] = 0
+        params["enabled"] = val_enabled
+        params["allow_traffic"] = ""
+        params["protocol"] = ""
+        params["src_addr"] = ""
+        params["src_prefix"] = ""
+        params["dst_addr"] = ""
+        params["dst_prefix"] = ""
+        params["ssport"] = ""
+        params["seport"] = ""
+        params["dsport"] = ""
+        params["deport"] = ""
+        params["del"] = val_del
+        params["idd"] = val_idd
+        params["sIpRange"] = ""
+        params["dsIpRange"] = ""
+        params["PortRange"] = ""
+        params["TMode"] = self._ipv6_filters_time.TMode
         if self._ipv6_filters_time.TMode == 1:
-            params['TRule'] = self._ipv6_filters_time.XmlGeneralTime
+            params["TRule"] = self._ipv6_filters_time.XmlGeneralTime
         elif self._ipv6_filters_time.TMode == 2:
-            params['TRule'] = self._ipv6_filters_time.XmlDailyTime
+            params["TRule"] = self._ipv6_filters_time.XmlDailyTime
         else:
-            params['TRule'] = 0
+            params["TRule"] = 0
 
         await self._async_ws_set_function(CMD_SET_IPV6_FILTER_RULE, params)
 
@@ -438,10 +439,10 @@ class ConnectBox:
             xml_root = element_tree.fromstring(raw)
             for elmt_log_event in xml_root.iter("eventlog"):
                 log_event = LogEvent(
-                elmt_log_event.find("prior").text,
-                elmt_log_event.find("text").text,
-                elmt_log_event.find("time").text,
-                int(elmt_log_event.find("t").text),
+                    elmt_log_event.find("prior").text,
+                    elmt_log_event.find("text").text,
+                    elmt_log_event.find("time").text,
+                    int(elmt_log_event.find("t").text),
                 )
                 self.eventlog.append(log_event)
         except (element_tree.ParseError, TypeError):
@@ -536,7 +537,9 @@ class ConnectBox:
 
         raise exceptions.ConnectBoxConnectionError()
 
-    async def _async_ws_set_function(self, function: int, params: dict) -> Optional[bool]:
+    async def _async_ws_set_function(
+        self, function: int, params: dict
+    ) -> Optional[bool]:
         """Execute a set command on UPC firmware webservice.
 
         Args:
@@ -546,12 +549,12 @@ class ConnectBox:
         try:
             # The 'token' parameter has to be first, and 'fun' second
             # or the UPC firmware will return an error
-            params_str = ''.join([f'&{key}={value}' for (key, value) in params.items()])
+            params_str = "".join([f"&{key}={value}" for (key, value) in params.items()])
 
             async with await self._session.post(
                 f"http://{self.host}/xml/setter.xml",
                 data=f"token={self.token}&fun={function}{params_str}",
-                #data=params,
+                # data=params,
                 headers=self.headers,
                 allow_redirects=False,
                 timeout=10,

--- a/connect_box/data.py
+++ b/connect_box/data.py
@@ -1,7 +1,7 @@
 """Handle Data attributes."""
 from datetime import datetime
 from ipaddress import IPv4Address, IPv6Address, ip_address as convert_ip
-from typing import Iterable, Union
+from typing import Iterable, Optional, Union
 
 import attr
 
@@ -142,6 +142,20 @@ class WanStatus:
     mac: str = attr.ib()
     ip4: IPv4Address = attr.ib(converter=convert_ip)
     # response includes ipv6 ranges, not specific addresses
+
+
+@attr.s
+class GlobalSettings:
+    """global settings are available regardless of auth status"""
+
+    # 1 if logged in, 0 if logged out
+    logged_in: bool = attr.ib()
+    # ISP identifier
+    operator_id: str = attr.ib()
+    # lockout due to other user
+    access_denied: bool = attr.ib()
+    # If logged in, software revision
+    sw_version: Optional[str] = attr.ib()
 
 
 @attr.s

--- a/connect_box/data.py
+++ b/connect_box/data.py
@@ -119,6 +119,14 @@ class CmSystemInfo:
 
 
 @attr.s
+class LanStatus:
+    upnp_enabled: bool = attr.ib()
+    mac: str = attr.ib()
+    ip4: IPv4Address = attr.ib(converter=convert_ip)
+    ip6: IPv6Address = attr.ib(converter=convert_ip)
+
+
+@attr.s
 class ServiceFlow:
     id: int = attr.ib()
     pMaxTrafficRate: int = attr.ib()

--- a/connect_box/data.py
+++ b/connect_box/data.py
@@ -110,6 +110,15 @@ class CmStatus:
 
 
 @attr.s
+class CmSystemInfo:
+    """Cable Modem system information"""
+
+    mac: str = attr.ib()
+    serial: str = attr.ib()
+    network_access: bool = attr.ib()
+
+
+@attr.s
 class ServiceFlow:
     id: int = attr.ib()
     pMaxTrafficRate: int = attr.ib()

--- a/connect_box/data.py
+++ b/connect_box/data.py
@@ -75,23 +75,30 @@ class Ipv6FilterInstance:
     allow: int = attr.ib()
     enabled: int = attr.ib()
 
+
 @attr.s
 class FiltersTimeMode:
     """Filters time setting."""
+
     TMode: int = attr.ib()
     XmlGeneralTime: str = attr.ib()
     XmlDailyTime: str = attr.ib()
 
+
 @attr.s
 class FilterStatesList:
     """A sequence of filter state instances."""
+
     entries: Iterable = attr.ib()
+
 
 @attr.s
 class FilterState:
     """A filter state instance."""
+
     idd: int = attr.ib()
     enabled: int = attr.ib()
+
 
 @attr.s
 class CmStatus:
@@ -120,10 +127,21 @@ class CmSystemInfo:
 
 @attr.s
 class LanStatus:
+    """Information about the private side of the gateway"""
+
     upnp_enabled: bool = attr.ib()
     mac: str = attr.ib()
     ip4: IPv4Address = attr.ib(converter=convert_ip)
     ip6: IPv6Address = attr.ib(converter=convert_ip)
+
+
+@attr.s
+class WanStatus:
+    """Information about the public side of the gateway"""
+
+    mac: str = attr.ib()
+    ip4: IPv4Address = attr.ib(converter=convert_ip)
+    # response includes ipv6 ranges, not specific addresses
 
 
 @attr.s
@@ -152,6 +170,7 @@ class Temperature:
 @attr.s
 class LogEvent:
     """An entry in the eventlog_table"""
+
     evPrio: str = attr.ib()
     evMsg: str = attr.ib()
     evTime: str = attr.ib()

--- a/connect_box/parsers.py
+++ b/connect_box/parsers.py
@@ -3,27 +3,34 @@ def _parse_general_time(xml_root):
 
     el = xml_root.find("GeneralTime/time")
     if el is not None:
-        return ','.join([str(int(h)*60+int(m)) for t in el.text.split('-') for h, m in [t.split(':')]])
+        return ",".join(
+            [
+                str(int(h) * 60 + int(m))
+                for t in el.text.split("-")
+                for h, m in [t.split(":")]
+            ]
+        )
     else:
         return None
+
 
 def _parse_daily_time(xml_root):
     """Convert contents of <DailyTime> to decimal mask"""
     mask = [[0 for h in range(24)] for d in range(7)]
     for instance in xml_root.findall("DailyTime/time_instance"):
-        day = int(instance.find('daily').text) -1
-        s, e = instance.find('time').text.split('-')
-        s, e = int(s), int(e)+1
-        mask[day][s:e] = [1] * (e-s)
+        day = int(instance.find("daily").text) - 1
+        s, e = instance.find("time").text.split("-")
+        s, e = int(s), int(e) + 1
+        mask[day][s:e] = [1] * (e - s)
 
     output = []
     for daybin in mask:
         daydec = 0
         for bit in daybin:
-            daydec = (daydec  << 1) | bit
+            daydec = (daydec << 1) | bit
         output.append(str(daydec))
 
-    if (output is not None and len(output)):
-        return ','.join(output)
+    if output is not None and len(output):
+        return ",".join(output)
     else:
         return None


### PR DESCRIPTION
Tinkering with an upgrade for the home assistant `upc_connect` integration and these api's will be required to support modern features. Also added an api to reboot the device for future automation.

Other changes:
* Fix consistency of results being overwritten or mutated between different methods (`self.x.clear()` vs `self.x = []`)
* Run `black` formatter on source
* Run `isort` on imports