### PR TITLE
Improve compatibility with Python3.8+ and Play(UPC) Connect Box

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ Python Client for interacting with the cable modem/router Compal CH7465LG which
 is provided under different names by various ISP in Europe.
 
 - UPC Connect Box (CH)
+- Play Connect Box (PL)
 - Irish Virgin Media Super Hub 3.0 (IE)
 - Ziggo Connectbox (NL)
 - Unitymedia Connect Box (DE)

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -531,7 +531,7 @@ class ConnectBox:
                 allow_redirects=False,
                 timeout=10,
             ) as response:
-                await response.text()
+                await response.read()
 
                 if response.status != 200:
                     _LOGGER.warning("Login error with code %d", response.status)

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -514,8 +514,8 @@ class ConnectBox:
                 headers=self.headers,
                 timeout=10,
             ) as response:
-                await response.text()
-                #self.token = response.cookies["sessionToken"].value
+                await response.read()
+                self.token = response.cookies["sessionToken"].value
 
         except (asyncio.TimeoutError, aiohttp.ClientError) as err:
             _LOGGER.error("Can not load login page from %s: %s", self.host, err)


### PR DESCRIPTION
Hello,

I use Home Assistant, which uses this library, but unfortunately I have encountered several problems with the latest version of this library on Python 3.11, when I tried to integrate my UPC Connect Box device. UPC Connect is now managed by [Play](https://www.play.pl/) as [Play acquired UPC Poland](https://www.telepolis.pl/wiadomosci/prawo-finanse-statystyki/play-i-upc-formalnie-polaczone).

The ConnectBox v0.3.0 on Python 3.7 works fine for me.

The connect-box v0.2.8 ([default version used by homeassistant](https://github.com/home-assistant/core/blob/2024.1.0b3/homeassistant/components/upc_connect/manifest.json#L8)) on Python 3.11 fails with the following error:
```
2024-01-02 01:20:50.504 ERROR (MainThread) [homeassistant.components.device_tracker] Error setting up platform legacy upc_connect
Traceback (most recent call last):
  File "/workspaces/homeassistant-core/homeassistant/components/device_tracker/legacy.py", line 297, in async_setup_legacy
    scanner = await self.platform.async_get_scanner(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/homeassistant-core/homeassistant/components/upc_connect/device_tracker.py", line 52, in async_get_scanner
    raise e
  File "/workspaces/homeassistant-core/homeassistant/components/upc_connect/device_tracker.py", line 43, in async_get_scanner
    await connect_box.async_initialize_token()
  File "/home/vscode/.local/lib/python3.11/site-packages/connect_box/__init__.py", line 380, in async_initialize_token
    await response.text()
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 1147, in text
    return self._body.decode(  # type: ignore[no-any-return,union-attr]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa3 in position 7389: invalid start byte
```
This error is caused by the fact that the HTML code of the page actually contains strange characters, but we are not really interested in that. 
![Screenshot 2024-01-02 at 02 22 12](https://github.com/krzysztof-kwitt/python-connect-box/assets/120908425/ac85ce99-b9fe-4cfd-b259-c8af78cc39a7)
We don't need to decode the response into text at all, because we are only interested in HTTP headers.
```
-await response.text()
+await response.read()
```
I fixed it locally, but when I wanted to use the development version it still didn't work because the session token is not sent in the 'POST /xml/setter.xml'  request.
<img width="703" alt="Screenshot 2024-01-02 at 02 28 27" src="https://github.com/krzysztof-kwitt/python-connect-box/assets/120908425/72d4ec1d-fa0e-4024-a6e5-eb47b785c13b">
Version v0.28 and v0.31 send the session token in the parameter.

<img width="715" alt="Screenshot 2024-01-02 at 02 32 04" src="https://github.com/krzysztof-kwitt/python-connect-box/assets/120908425/2b5d7c56-b2cf-4033-95c0-89046162f5c0"> 

This was caused by this [commit](https://github.com/home-assistant-ecosystem/python-connect-box/commit/6e8b43583b9f87677a40c0296e74e7892bdb24d8), which looks like a mistake.

```
Connect Box device information

Hardware version	:	5.01
Software version	:	CH7465LG-NCIP-6.15.31p1-NOSH
```
